### PR TITLE
Use new --test-instance argument consistently in all test runners

### DIFF
--- a/src/testbed_micropython/testrunspecs/run_multinet.py
+++ b/src/testbed_micropython/testrunspecs/run_multinet.py
@@ -46,8 +46,6 @@ class TestRunReference(TestRun):
 
         self.setup(testargs=testargs)
 
-        serial_port_instance0 = tentacle_instance0.dut.get_tty()
-        serial_port_instance1 = tentacle_instance1.dut.get_tty()
         # Run tests
         cwd = testargs.repo_micropython_tests / MICROPYTHON_DIRECTORY_TESTS
         list_tests = [str(f.relative_to(cwd)) for f in cwd.glob(file_pattern)]
@@ -64,8 +62,8 @@ class TestRunReference(TestRun):
             sys.executable,
             self.testrun_spec.command_executable,
             f"--result-dir={testargs.testresults_directory.directory_test}",
-            f"--instance=pyb:{serial_port_instance0}",
-            f"--instance=pyb:{serial_port_instance1}",
+            f"--test-instance=port:{tentacle_instance0.dut.get_tty()}",
+            f"--test-instance=port:{tentacle_instance1.dut.get_tty()}",
             *list_tests,
         ]
         subprocess_run(

--- a/src/testbed_micropython/testrunspecs/run_natmodtests.py
+++ b/src/testbed_micropython/testrunspecs/run_natmodtests.py
@@ -232,15 +232,13 @@ class TestRunRunTests(TestRun):
         ]
 
         # Run tests
-        serial_port = tentacle.dut.get_tty()
         logfile = testargs.testresults_directory("testresults.txt").filename
         EVENTLOGCALLBACK.log(msg=f"Logfile: {relative_cwd(logfile)}")
         args = [
             sys.executable,
             *self.testrun_spec.command,
             f"--result-dir={testargs.testresults_directory.directory_test}",
-            "--pyboard",
-            f"--device={serial_port}",
+            f"--test-instance=port:{tentacle.dut.get_tty()}",
         ] + tests_natmod
         subprocess_run(
             args=args,

--- a/src/testbed_micropython/testrunspecs/run_perftest.py
+++ b/src/testbed_micropython/testrunspecs/run_perftest.py
@@ -51,8 +51,7 @@ class TestRunPerfTest(TestRun):
             sys.executable,
             *self.testrun_spec.command,
             f"--result-dir={testargs.testresults_directory.directory_test}",
-            "--pyboard",
-            f"--device={tentacle.dut.get_tty()}",
+            f"--test-instance=port:{tentacle.dut.get_tty()}",
             *perftest_args,
         ]
         subprocess_run(

--- a/src/testbed_micropython/testrunspecs/runtests.py
+++ b/src/testbed_micropython/testrunspecs/runtests.py
@@ -101,8 +101,7 @@ class TestRunRunTests(TestRun):
             sys.executable,
             *self.testrun_spec.command,
             f"--result-dir={testargs.testresults_directory.directory_test}",
-            f"-t=port:{serial_port}",
-            # f"--target={target}",
+            f"--test-instance=port:{serial_port}",
             "--jobs=1",
             # "misc/cexample_class.py",
         ]

--- a/src/testbed_micropython/testrunspecs/runtests_net_inet.py
+++ b/src/testbed_micropython/testrunspecs/runtests_net_inet.py
@@ -69,7 +69,7 @@ class TestRunRunTests(TestRun):
         args = [
             sys.executable,
             *self.testrun_spec.command,
-            f"-t=port:{serial_port}",
+            f"--test-instance=port:{serial_port}",
             "--jobs=1",
             f"--result-dir={testargs.testresults_directory.directory_test}",
         ]


### PR DESCRIPTION
The tests runners were recently updated to all use the same command line arguments.

Note: this has not been tested yet!