### PR TITLE
Set specific run-perfbench.py arguments on ADA_ITSYBITSY_M0

### DIFF
--- a/src/testbed_micropython/tentacle_specs.py
+++ b/src/testbed_micropython/tentacle_specs.py
@@ -70,7 +70,9 @@ See: https://micropython.org/download/ADAFRUIT_ITSYBITSY_M0_EXPRESS/
     # -  Push the reset button twice or call machine.bootloader(). A drive
     #   icon should appear representing a virtual drive.
     # -  Copy the .uf2 file with the required firmware to that drive.
-    mcu_config=McuConfig(),
+    mcu_config=McuConfig(
+        micropython_perftest_args=["48", "20"],
+    ),
 )
 
 


### PR DESCRIPTION
To match the boards frequency of 48MHz and GC heap of about 20k.

All perfbench tests should now pass on this board.