### PR TITLE
Remove FLASH_512K build variant for LOLIN_D1_MINI (esp8266 board)

### DIFF
--- a/src/testbed_micropython/tentacle_specs.py
+++ b/src/testbed_micropython/tentacle_specs.py
@@ -373,7 +373,7 @@ v1.0: initial
         EnumFut.FUT_EXTMOD_HARDWARE,
         EnumFut.FUT_WLAN,
     ],
-    tags="board=ESP8266_GENERIC,build_variants=:FLASH_512K,mcu=esp8266,programmer=esptool",
+    tags="board=ESP8266_GENERIC,mcu=esp8266,programmer=esptool",
     programmer_args=[
         "--chip=esp8266",
         "--baud=1000000",


### PR DESCRIPTION
The FLASH_512K variant is too limited in features (eg no filesystem) and errors out on many tests.  It's not worth it endlessly tweaking the test suite just to test this variant, because testing it doesn't really add much in terms of test coverage.

Note: I have not tested this change, but I assume it will work :smile: 