### PR TITLE
Add mpremote tests as a new test group

### DIFF
--- a/docs/design/25_testselection.rst
+++ b/docs/design/25_testselection.rst
@@ -49,12 +49,18 @@ All known tests are registered in the module-level list ``_TESTRUN_SPECS`` in
         runtests.TESTRUNSPEC_RUNTESTS_EXTMOD_HARDWARE,
         runtests.TESTRUNSPEC_RUNTESTS_EXTMOD_HARDWARE_NATIVE,
         run_natmodtests.TESTRUNSPEC_RUN_NATMODTESTS,
+        run_mpremote_tests.TESTRUNSPEC_RUN_MPREMOTE_TESTS,
         run_flash_format.TESTRUNSPEC_RUN_FLASH_FORMAT,
     ]
 
 Each :class:`TestRunSpec` carries a ``label`` (e.g. ``RUN-TESTS_STANDARD``), a
 ``required_fut`` (:class:`EnumFut`), and the ``command`` to execute.  The dict
 ``DICT_TESTRUN_SPECS`` maps every label to its spec and is used for validation.
+
+Most commands live in the ``tests/`` directory of the MicroPython repo.  A spec
+may override this via the ``command_subdir`` field – for example
+``RUN-MPREMOTE_TESTS`` runs ``tools/mpremote/tests/run-mpremote-tests.sh -t
+<port>``.
 
 Run ``mptest list-tests`` to print the current inventory at any time.
 
@@ -147,6 +153,10 @@ Examples
 Run a single test group::
 
     mptest test --only-test=RUN-TESTS_STANDARD
+
+Run the mpremote test suite (``tools/mpremote/tests/run-mpremote-tests.sh``)::
+
+    mptest test --only-test=RUN-MPREMOTE_TESTS
 
 Run a test group with custom arguments (overrides the registered command)::
 

--- a/src/testbed_micropython/mptest/util_testrunner.py
+++ b/src/testbed_micropython/mptest/util_testrunner.py
@@ -46,6 +46,7 @@ from ..testcollection.baseclasses_spec import ConnectedTentacles
 from ..testcollection.testrun_specs import TestArgs, TestRun, TestRunSpec
 from ..testrunspecs import (
     run_flash_format,
+    run_mpremote_tests,
     run_multinet,
     run_natmodtests,
     run_perftest,
@@ -88,6 +89,7 @@ _TESTRUN_SPECS = [
     runtests.TESTRUNSPEC_RUNTESTS_EXTMOD_HARDWARE,
     runtests.TESTRUNSPEC_RUNTESTS_EXTMOD_HARDWARE_NATIVE,
     run_natmodtests.TESTRUNSPEC_RUN_NATMODTESTS,
+    run_mpremote_tests.TESTRUNSPEC_RUN_MPREMOTE_TESTS,
     # We probably had corrupt filesystems due to powerdrops
     # Now these problems have gone and we can uncommet flash format
     # 2026-04-29: Again, the filesystem of a rpi2 was corrupt.

--- a/src/testbed_micropython/report_test/util_baseclasses.py
+++ b/src/testbed_micropython/report_test/util_baseclasses.py
@@ -451,7 +451,7 @@ class ResultTestGroup:
         if testspec is None:
             return self.testgroup
 
-        python_test = MICROPYTHON_DIRECTORY_TESTS + "/" + testspec.command_executable
+        python_test = testspec.command_subdir + "/" + testspec.command_executable
         label_intuitive = testspec.label_intuitive
 
         # Find the git_ref for the micropython tests repository

--- a/src/testbed_micropython/testcollection/testrun_specs.py
+++ b/src/testbed_micropython/testcollection/testrun_specs.py
@@ -353,6 +353,11 @@ class TestRunSpec:
     0: low
     10: high
     """
+    command_subdir: str = MICROPYTHON_DIRECTORY_TESTS
+    """
+    Directory (relative to the micropython repo) which contains the command.
+    Example: 'tests' for 'run-tests.py', 'tools/mpremote/tests' for 'run-mpremote-tests.sh'.
+    """
 
     def __post_init__(self) -> None:
         assert isinstance(self.label, str)
@@ -363,6 +368,7 @@ class TestRunSpec:
         assert isinstance(self.timeout_s, float)
         assert isinstance(self.testrun_class, type(TestRun))
         assert isinstance(self.tsvs_todo, TentacleSpecVariants)
+        assert isinstance(self.command_subdir, str)
 
     @property
     def command_executable(self) -> str:

--- a/src/testbed_micropython/testrunspecs/run_mpremote_tests.py
+++ b/src/testbed_micropython/testrunspecs/run_mpremote_tests.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import re
+
+from octoprobe.util_baseclasses import OctoprobeTestException
+
+from ..constants import EnumFut
+from ..testcollection.baseclasses_spec import TentacleVariant
+from ..testcollection.constants import (
+    ENV_PYTHONUNBUFFERED,
+    TIMEOUT_FLASH_S,
+)
+from ..testcollection.testrun_specs import (
+    TestArgs,
+    TestRun,
+    TestRunSpec,
+)
+from ..util_multiprocessing import EVENTLOGCALLBACK
+from ..util_subprocess_tentacle import tentacle_subprocess_run
+
+logger = logging.getLogger(__file__)
+
+MPREMOTE_TESTS_SUBDIR = "tools/mpremote/tests"
+"""
+Directory (relative to the micropython repo) which contains 'run-mpremote-tests.sh'.
+"""
+
+MPREMOTE_TESTS_COMMAND = "run-mpremote-tests.sh"
+
+_RE_RESULT = re.compile(r"^(?P<name>\S+\.sh):\s+(?P<result>OK|FAIL|CRASH|skip)$")
+"""
+Matches the per-test result lines emitted by 'run-mpremote-tests.sh'.
+
+Example:
+./test_filesystem.sh: OK
+./test_run.sh: FAIL
+"""
+
+_RESULT_TO_OUTCOME = {
+    "OK": "pass",
+    "FAIL": "fail",
+    "CRASH": "fail",
+    "skip": "skip",
+}
+
+
+class TestRunMpremoteTests(TestRun):
+    """
+    This test runs: tools/mpremote/tests/run-mpremote-tests.sh
+
+    https://github.com/micropython/micropython/blob/master/tools/mpremote/tests/README.md
+    https://github.com/micropython/micropython/blob/master/tools/mpremote/tests/run-mpremote-tests.sh
+    """
+
+    def test(self, testargs: TestArgs) -> None:
+        tentacle_variant = self.tentacle_variant
+        assert isinstance(tentacle_variant, TentacleVariant)
+
+        tentacle = tentacle_variant.tentacle
+        tentacle_spec = tentacle.tentacle_spec
+        assert tentacle_spec.mcu_config is not None
+
+        self.skip_if_no_filesystem()
+
+        serial_port = tentacle.dut.get_tty()
+
+        # Run tests
+        logfile = testargs.testresults_directory("testresults.txt").filename
+        EVENTLOGCALLBACK.log(
+            msg=f"Logfile: {testargs.testresults_directory.render_relative(logfile)}"
+        )
+        args = [
+            f"./{self.testrun_spec.command_executable}",
+            *self.testrun_spec.command_args,
+            "-t",
+            serial_port,
+        ]
+        tentacle_subprocess_run(
+            args=args,
+            cwd=testargs.repo_micropython_tests / self.testrun_spec.command_subdir,
+            testrun=self,
+            env=ENV_PYTHONUNBUFFERED,
+            logfile=logfile,
+            timeout_s=self.timeout_s,
+        )
+
+        self._evaluate_results(testargs=testargs, logfile=logfile)
+
+    def _evaluate_results(self, testargs: TestArgs, logfile: pathlib.Path) -> None:
+        """
+        'run-mpremote-tests.sh' reports per-test 'OK'/'FAIL'/'CRASH'/'skip' on
+        stdout and always exits with returncode 0.
+
+        We parse the output to build '_results.json' (so the outcomes appear in
+        the report) and raise an exception if any test failed or crashed.
+        """
+        results: list[list[str]] = []
+        failures: list[str] = []
+        for line in logfile.read_text(errors="replace").splitlines():
+            match = _RE_RESULT.match(line.strip())
+            if match is None:
+                continue
+            name = match.group("name")
+            result = match.group("result")
+            outcome = _RESULT_TO_OUTCOME[result]
+            results.append([name, outcome, "" if outcome != "fail" else result])
+            if outcome == "fail":
+                failures.append(f"{name}: {result}")
+
+        filename_results = (
+            testargs.testresults_directory.directory_test / "_results.json"
+        )
+        filename_results.write_text(json.dumps({"args": {}, "results": results}))
+
+        if failures:
+            raise OctoprobeTestException(
+                f"mpremote tests failed: {', '.join(failures)}"
+            )
+
+
+TESTRUNSPEC_RUN_MPREMOTE_TESTS = TestRunSpec(
+    label="RUN-MPREMOTE_TESTS",
+    label_intuitive="run-mpremote-tests.sh",
+    label_order="c_h",
+    helptext="Run the mpremote test suite",
+    command=[MPREMOTE_TESTS_COMMAND],
+    command_subdir=MPREMOTE_TESTS_SUBDIR,
+    required_fut=EnumFut.FUT_MCU_ONLY,
+    requires_reference_tentacle=False,
+    testrun_class=TestRunMpremoteTests,
+    timeout_s=5 * 60.0 + TIMEOUT_FLASH_S,
+)

--- a/tests/test_mpremote_tests.py
+++ b/tests/test_mpremote_tests.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from testbed_micropython.constants import EnumFut
+from testbed_micropython.mptest import util_testrunner
+from testbed_micropython.mptest.util_baseclasses import ArgsQuery
+from testbed_micropython.testrunspecs import run_mpremote_tests
+
+LABEL = "RUN-MPREMOTE_TESTS"
+
+
+def test_mpremote_registered() -> None:
+    """The mpremote test group is part of the static inventory."""
+    assert LABEL in util_testrunner.DICT_TESTRUN_SPECS
+    spec = util_testrunner.DICT_TESTRUN_SPECS[LABEL]
+    assert spec is run_mpremote_tests.TESTRUNSPEC_RUN_MPREMOTE_TESTS
+    assert spec.required_fut is EnumFut.FUT_MCU_ONLY
+    assert spec.requires_reference_tentacle is False
+    assert spec.command_executable == "run-mpremote-tests.sh"
+    assert spec.command_subdir == "tools/mpremote/tests"
+
+
+def test_mpremote_in_get_testrun_specs() -> None:
+    """Without a query, the group is enumerated (used for shell completion)."""
+    labels = [spec.label for spec in util_testrunner.get_testrun_specs()]
+    assert LABEL in labels
+
+
+def test_mpremote_only_test_selection() -> None:
+    """'--only-test=RUN-MPREMOTE_TESTS' selects exactly this group."""
+    query = ArgsQuery(only_test={LABEL})
+    specs = util_testrunner.get_testrun_specs(query=query)
+    assert [spec.label for spec in specs] == [LABEL]
+
+
+def test_mpremote_skip_test_selection() -> None:
+    """'--skip-test=RUN-MPREMOTE_TESTS' removes this group."""
+    query = ArgsQuery(skip_test={LABEL})
+    labels = [spec.label for spec in util_testrunner.get_testrun_specs(query=query)]
+    assert LABEL not in labels


### PR DESCRIPTION
Hello Hans,

Just to be clear - this is an AI generated PR , and as I have no tentacles - I have no way to actually test this PR.
The goal is to allow testing of the existing mpremote tests against the different tenatacles in order to find regeressions before cutting a version.

Closes #83 

