### PR TITLE
Copy PEM certificates to device for network tests

### DIFF
--- a/src/testbed_micropython/mptest/util_common.py
+++ b/src/testbed_micropython/mptest/util_common.py
@@ -120,7 +120,7 @@ def copy_certificates(dut: TentacleDut, src: pathlib.Path) -> None:
 
     dut.mp_remote.set_rtc()
 
-    for certificate in src.glob("*.der"):
+    for certificate in list(src.glob("*.der")) + list(src.glob("*.pem")):
         logger.info(f"{dut.label}: copy_certificates(): {certificate.name}")
         dut.mp_remote.cp(certificate, ":")
 


### PR DESCRIPTION
MicroPython now supports loading `.pem` certificate files and has a test for it, so copy them in addition to `.der`.